### PR TITLE
ci: allow dependabot updates for all GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    # TODO: Dependabot only updates hashicorp GHAs in the template repository, the following lines can be removed for consumers of this template
-    allow:
-      - dependency-name: "hashicorp/*"


### PR DESCRIPTION
Allow Dependabot updates for all GitHub actions including versioning tool: https://github.com/Oliver-Binns/Versioning