### PR TITLE
fix: enable implicit permissions

### DIFF
--- a/docs/resources/app_iam.md
+++ b/docs/resources/app_iam.md
@@ -21,3 +21,8 @@ Manage app level access to the Google Play Console
 - `permissions` (Set of String) Permissions for the user which apply to this specific app:
 				https://developers.google.com/android-publisher/api-ref/rest/v3/grants#applevelpermission
 - `user_id` (String) The ID for the user: this is the email they use to login to Google Play
+
+### Read-Only
+
+- `expanded_permissions` (Set of String) Permissions for the user which apply to this specific app:
+				https://developers.google.com/android-publisher/api-ref/rest/v3/grants#applevelpermission

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.26.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.12.0
-	github.com/oliver-binns/googleplay-go v0.0.0-20250421130344-13573572b08b
+	github.com/oliver-binns/googleplay-go v0.0.0-20250421153114-2d0a7a09c1a1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/oliver-binns/googleplay-go v0.0.0-20250421130344-13573572b08b h1:/6a2lt/cDPjsqtjHSEzOWVKLC9jg1QbP9OXbu+UYrzo=
-github.com/oliver-binns/googleplay-go v0.0.0-20250421130344-13573572b08b/go.mod h1:JUBt/rWkAOkR9qSxKVH4Iid37RrExqIQheP5MVXLy/Y=
+github.com/oliver-binns/googleplay-go v0.0.0-20250421153114-2d0a7a09c1a1 h1:8/hsBAmSWi59a+4P724UtyZAvHmjJpBq8MyBwEo1Pfc=
+github.com/oliver-binns/googleplay-go v0.0.0-20250421153114-2d0a7a09c1a1/go.mod h1:JUBt/rWkAOkR9qSxKVH4Iid37RrExqIQheP5MVXLy/Y=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/provider/app_iam_permissions_modifier.go
+++ b/internal/provider/app_iam_permissions_modifier.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	"context"
+	"slices"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/oliver-binns/googleplay-go/users"
+)
+
+func expandAppPermissionsPlanModifier(permissions path.Path) planmodifier.Set {
+	return &appPermissionsExpansionModifier{
+		permissions: permissions,
+	}
+}
+
+type appPermissionsExpansionModifier struct {
+	permissions path.Path
+}
+
+func (m *appPermissionsExpansionModifier) Description(ctx context.Context) string {
+	return "Expands Google Play Permissions to include explicitly granted permissions"
+}
+
+func (m *appPermissionsExpansionModifier) MarkdownDescription(ctx context.Context) string {
+	return "Expands Google Play Permissions to include explicitly granted permissions"
+}
+
+func (m *appPermissionsExpansionModifier) PlanModifySet(
+	ctx context.Context,
+	req planmodifier.SetRequest,
+	resp *planmodifier.SetResponse,
+) {
+	// fetch declared permissions:
+	var permissions types.Set // contrived example is using string attributes
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, m.permissions, &permissions)...)
+
+	// expand the permissions
+	expanded_permissions := []users.AppLevelPermission{}
+	diag := req.PlanValue.ElementsAs(ctx, &permissions, false)
+	resp.Diagnostics.Append(diag...)
+
+	for _, permission := range expanded_permissions {
+		for _, inherited := range permission.Expand() {
+			if !slices.Contains(expanded_permissions, inherited) {
+				// missing from the plan:
+				expanded_permissions = append(expanded_permissions, inherited)
+			}
+		}
+	}
+
+	// write the expanded permissions back to the plan
+	planValue, diag := types.SetValueFrom(ctx, req.PlanValue.ElementType(ctx), permissions)
+	resp.Diagnostics.Append(diag...)
+	resp.PlanValue = planValue
+}

--- a/internal/provider/app_iam_resource.go
+++ b/internal/provider/app_iam_resource.go
@@ -3,12 +3,15 @@ package provider
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oliver-binns/googleplay-go"
@@ -27,9 +30,10 @@ type AppIAMResource struct {
 }
 
 type appIAMResourceModel struct {
-	UserID      types.String `tfsdk:"user_id"`
-	AppID       types.String `tfsdk:"app_id"`
-	Permissions types.Set    `tfsdk:"permissions"`
+	UserID              types.String `tfsdk:"user_id"`
+	AppID               types.String `tfsdk:"app_id"`
+	Permissions         types.Set    `tfsdk:"permissions"`
+	ExpandedPermissions types.Set    `tfsdk:"expanded_permissions"`
 }
 
 func (m *appIAMResourceModel) Name(developerID string) string {
@@ -49,16 +53,31 @@ func (r *AppIAMResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"user_id": schema.StringAttribute{
 				MarkdownDescription: "The ID for the user: this is the email they use to login to Google Play",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"app_id": schema.StringAttribute{
 				MarkdownDescription: "The app / package ID to grant access to",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"permissions": schema.SetAttribute{
 				MarkdownDescription: `Permissions for the user which apply to this specific app:
 				https://developers.google.com/android-publisher/api-ref/rest/v3/grants#applevelpermission`,
 				ElementType: types.StringType,
 				Required:    true,
+			},
+			"expanded_permissions": schema.SetAttribute{
+				MarkdownDescription: `Permissions for the user which apply to this specific app:
+				https://developers.google.com/android-publisher/api-ref/rest/v3/grants#applevelpermission`,
+				ElementType: types.StringType,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Set{
+					expandAppPermissionsPlanModifier(path.Root("permissions")),
+				},
 			},
 		},
 	}
@@ -93,12 +112,31 @@ func (r *AppIAMResource) ValidateConfig(ctx context.Context, req resource.Valida
 		return
 	}
 
+	// Each grant must contain a valid permission
 	if len(data.Permissions.Elements()) == 0 {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("permissions"),
-			"Invalid Permissions Configuration",
+			"Invalid permissions configuration",
 			"permissions must contain at least one permission.",
 		)
+	}
+
+	// Warn user if they are using an implicit permission
+	permissions := []users.AppLevelPermission{}
+	diag := data.Permissions.ElementsAs(ctx, &permissions, false)
+	resp.Diagnostics.Append(diag...)
+	for _, permission := range permissions {
+		for _, inherited := range permission.Expand() {
+			if !slices.Contains(permissions, inherited) {
+				resp.Diagnostics.AddWarning(
+					"Granting implicit permission",
+					fmt.Sprintf(
+						"The permission '%s' is inherited from '%s', but it is not explicitly granted.",
+						inherited, permission,
+					),
+				)
+			}
+		}
 	}
 }
 
@@ -137,7 +175,7 @@ func (r *AppIAMResource) Create(ctx context.Context, req resource.CreateRequest,
 	data.UserID = types.StringValue(components[3])
 	data.AppID = types.StringValue(components[5])
 
-	data.Permissions, diag = types.SetValueFrom(ctx, types.StringType, grant.AppLevelPermissions)
+	data.ExpandedPermissions, diag = types.SetValueFrom(ctx, types.StringType, grant.AppLevelPermissions)
 	resp.Diagnostics.Append(diag...)
 
 	// Write logs using the tflog package
@@ -244,7 +282,7 @@ func (r *AppIAMResource) Update(ctx context.Context, req resource.UpdateRequest,
 	data.UserID = types.StringValue(components[3])
 	data.AppID = types.StringValue(components[5])
 
-	data.Permissions, diag = types.SetValueFrom(ctx, types.StringType, grant.AppLevelPermissions)
+	data.ExpandedPermissions, diag = types.SetValueFrom(ctx, types.StringType, grant.AppLevelPermissions)
 	resp.Diagnostics.Append(diag...)
 
 	// Save updated data into Terraform state

--- a/internal/provider/app_iam_resource_test.go
+++ b/internal/provider/app_iam_resource_test.go
@@ -45,6 +45,13 @@ func TestAccAppIAMResource(t *testing.T) {
 							knownvalue.StringExact("CAN_VIEW_APP_QUALITY"),
 						}),
 					),
+					statecheck.ExpectKnownValue(
+						"googleplay_app_iam.test_app",
+						tfjsonpath.New("expanded_permissions"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("CAN_VIEW_APP_QUALITY"),
+						}),
+					),
 				},
 			},
 			// Test update permissions
@@ -68,6 +75,49 @@ func TestAccAppIAMResource(t *testing.T) {
 						"googleplay_app_iam.test_app",
 						tfjsonpath.New("permissions"),
 						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("CAN_VIEW_NON_FINANCIAL_DATA"),
+							knownvalue.StringExact("CAN_VIEW_APP_QUALITY"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"googleplay_app_iam.test_app",
+						tfjsonpath.New("expanded_permissions"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("CAN_VIEW_NON_FINANCIAL_DATA"),
+							knownvalue.StringExact("CAN_VIEW_APP_QUALITY"),
+						}),
+					),
+				},
+			},
+			// Test update permissions with implicit grant
+			{
+				Config: testAccAppIAMResourceConfig(
+					accountEmail,
+					`"CAN_REPLY_TO_REVIEWS"`,
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"googleplay_app_iam.test_app",
+						tfjsonpath.New("app_id"),
+						knownvalue.StringExact("4973279986054171407"),
+					),
+					statecheck.ExpectKnownValue(
+						"googleplay_app_iam.test_app",
+						tfjsonpath.New("user_id"),
+						knownvalue.StringExact(accountEmail),
+					),
+					statecheck.ExpectKnownValue(
+						"googleplay_app_iam.test_app",
+						tfjsonpath.New("permissions"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("CAN_REPLY_TO_REVIEWS"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"googleplay_app_iam.test_app",
+						tfjsonpath.New("expanded_permissions"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("CAN_REPLY_TO_REVIEWS"),
 							knownvalue.StringExact("CAN_VIEW_NON_FINANCIAL_DATA"),
 							knownvalue.StringExact("CAN_VIEW_APP_QUALITY"),
 						}),


### PR DESCRIPTION
The Google Play Console API implicitly adds additional permissions when required.
https://github.com/Oliver-Binns/googleplay-go/pull/23

This pull request introduces a computed attribute `expanded_permissions` that tracks these additional permissions. 
This ensures that the additional permissions are added to the plan so they are not returned unexpectedly.