### PR TITLE
ci: create release with goreleaser rather than versioning package

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -13,9 +13,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Deploy to App Store Connect
+  determine_increment:
+    name: Create GitHub tag
     runs-on: macos-15
+    outputs:
+      should_release: ${{ steps.versioning.outputs.release_version }}
 
     steps:
       - name: Add Path Globally
@@ -23,7 +25,37 @@ jobs:
 
       - name: Increment Version
         id: versioning
-        uses: Oliver-Binns/Versioning@ea913b155653c7f72c3ecb01768d8103ad57f639 # 1.2.2
+        uses: Oliver-Binns/Versioning@768ec693878abe2f357b151572915d2ab654d13e # 1.3.2
         with:
           ACTION_TYPE: Release
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_ONLY: true
+  
+  goreleaser:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: determine_increment
+    if: needs.determine_increment.outputs.should_release
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Allow goreleaser to access older tag information.
+          fetch-depth: 0
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
+        with:
+          args: release --clean
+        env:
+          # GitHub sets the GITHUB_TOKEN secret automatically.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
Uses versioning tool to determine if a release is required, then creates a tag if so.
Runs the Go releaser to create the GitHub release and build the artefacts.