### PR TITLE
fix: enable implicit permissions for users

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -26,4 +26,6 @@ Manage user accounts in the Google Play Console
 
 ### Read-Only
 
+- `expanded_permissions` (Set of String) Permissions for the user which apply to this specific app:
+				https://developers.google.com/android-publisher/api-ref/rest/v3/grants#applevelpermission
 - `name` (String) The name of the user

--- a/internal/provider/user_permissions_modifier.go
+++ b/internal/provider/user_permissions_modifier.go
@@ -10,25 +10,25 @@ import (
 	"github.com/oliver-binns/googleplay-go/users"
 )
 
-func expandAppPermissionsPlanModifier(permissions path.Path) planmodifier.Set {
-	return &appPermissionsExpansionModifier{
+func expandUserPermissionsPlanModifier(permissions path.Path) planmodifier.Set {
+	return &userPermissionsExpansionModifier{
 		permissions: permissions,
 	}
 }
 
-type appPermissionsExpansionModifier struct {
+type userPermissionsExpansionModifier struct {
 	permissions path.Path
 }
 
-func (m *appPermissionsExpansionModifier) Description(ctx context.Context) string {
-	return "Expands app-specific Google Play Permissions to include implicitly granted permissions"
+func (m *userPermissionsExpansionModifier) Description(ctx context.Context) string {
+	return "Expands Google Play Permissions for users to include implicitly granted permissions"
 }
 
-func (m *appPermissionsExpansionModifier) MarkdownDescription(ctx context.Context) string {
-	return "Expands app-specific Google Play Permissions to include implicitly granted permissions"
+func (m *userPermissionsExpansionModifier) MarkdownDescription(ctx context.Context) string {
+	return "Expands Google Play Permissions for users to include implicitly granted permissions"
 }
 
-func (m *appPermissionsExpansionModifier) PlanModifySet(
+func (m *userPermissionsExpansionModifier) PlanModifySet(
 	ctx context.Context,
 	req planmodifier.SetRequest,
 	resp *planmodifier.SetResponse,
@@ -38,7 +38,7 @@ func (m *appPermissionsExpansionModifier) PlanModifySet(
 	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, m.permissions, &permissions)...)
 
 	// expand the permissions
-	expanded_permissions := []users.AppLevelPermission{}
+	expanded_permissions := []users.DeveloperLevelPermission{}
 	diag := req.PlanValue.ElementsAs(ctx, &permissions, false)
 	resp.Diagnostics.Append(diag...)
 

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -77,9 +77,62 @@ func TestAccUserResource(t *testing.T) {
 					),
 					statecheck.ExpectKnownValue(
 						"googleplay_user.oliver",
-						tfjsonpath.New("global_permissions"),
+						tfjsonpath.New("expanded_permissions"),
 						knownvalue.SetExact([]knownvalue.Check{
 							knownvalue.StringExact("CAN_MANAGE_TRACK_USERS_GLOBAL"),
+						}),
+					),
+				},
+			},
+			// Test update global permissions with implicit grant
+			{
+				Config: testAccUserResourceConfig(
+					accountEmail,
+					`"CAN_MANAGE_PERMISSIONS_GLOBAL"`,
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"googleplay_user.oliver",
+						tfjsonpath.New("email"),
+						knownvalue.StringExact(accountEmail),
+					),
+					statecheck.ExpectKnownValue(
+						"googleplay_user.oliver",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(
+							fmt.Sprintf(
+								"developers/5166846112789481453/users/%s",
+								accountEmail,
+							),
+						),
+					),
+					statecheck.ExpectKnownValue(
+						"googleplay_user.oliver",
+						tfjsonpath.New("global_permissions"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("CAN_MANAGE_PERMISSIONS_GLOBAL"),
+						}),
+					),
+					statecheck.ExpectKnownValue(
+						"googleplay_user.oliver",
+						tfjsonpath.New("expanded_permissions"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.StringExact("CAN_VIEW_FINANCIAL_DATA_GLOBAL"),
+							knownvalue.StringExact("CAN_MANAGE_PERMISSIONS_GLOBAL"),
+							knownvalue.StringExact("CAN_EDIT_GAMES_GLOBAL"),
+							knownvalue.StringExact("CAN_PUBLISH_GAMES_GLOBAL"),
+							knownvalue.StringExact("CAN_REPLY_TO_REVIEWS_GLOBAL"),
+							knownvalue.StringExact("CAN_MANAGE_PUBLIC_APKS_GLOBAL"),
+							knownvalue.StringExact("CAN_MANAGE_TRACK_APKS_GLOBAL"),
+							knownvalue.StringExact("CAN_MANAGE_TRACK_USERS_GLOBAL"),
+							knownvalue.StringExact("CAN_MANAGE_PUBLIC_LISTING_GLOBAL"),
+							knownvalue.StringExact("CAN_MANAGE_DRAFT_APPS_GLOBAL"),
+							knownvalue.StringExact("CAN_CREATE_MANAGED_PLAY_APPS_GLOBAL"),
+							knownvalue.StringExact("CAN_MANAGE_ORDERS_GLOBAL"),
+							knownvalue.StringExact("CAN_MANAGE_APP_CONTENT_GLOBAL"),
+							knownvalue.StringExact("CAN_VIEW_NON_FINANCIAL_DATA_GLOBAL"),
+							knownvalue.StringExact("CAN_VIEW_APP_QUALITY_GLOBAL"),
+							knownvalue.StringExact("CAN_MANAGE_DEEPLINKS_GLOBAL"),
 						}),
 					),
 				},


### PR DESCRIPTION
The Google Play Console API implicitly adds additional permissions when required.
https://github.com/Oliver-Binns/googleplay-go/pull/26

This pull request introduces a computed attribute `expanded_permissions` that tracks these additional permissions.
This ensures that the additional permissions are added to the plan so they are not returned **unexpectedly**.

This is a follow-on pull request similar to the handling of app-specific permissions: https://github.com/Oliver-Binns/terraform-provider-googleplay/pull/22