### PR TITLE
feat: add support for importing Google Play Console users into Terraform

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -28,4 +28,5 @@ Manage user accounts in the Google Play Console
 
 - `expanded_permissions` (Set of String) Permissions for the user which apply to this specific app:
 				https://developers.google.com/android-publisher/api-ref/rest/v3/grants#applevelpermission
+- `id` (String) The ID of the user, which is their email address.
 - `name` (String) The name of the user

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -30,6 +30,7 @@ type UserResource struct {
 }
 
 type userResourceModel struct {
+	ID                  types.String `tfsdk:"id"`
 	Name                types.String `tfsdk:"name"`
 	Email               types.String `tfsdk:"email"`
 	GlobalPermissions   types.Set    `tfsdk:"global_permissions"`
@@ -46,6 +47,10 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 		MarkdownDescription: "Manage user accounts in the Google Play Console",
 
 		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				MarkdownDescription: "The ID of the user, which is their email address.",
+				Computed:            true,
+			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "The name of the user",
 				Computed:            true,
@@ -146,6 +151,7 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
+	data.ID = types.StringValue(user.Email)
 	data.Name = types.StringValue(user.Name)
 	data.Email = types.StringValue(user.Email)
 
@@ -190,6 +196,7 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	for _, user := range users {
 		if user.Email == email {
+			data.ID = types.StringValue(user.Email)
 			data.Name = types.StringValue(user.Name)
 			data.Email = types.StringValue(user.Email)
 
@@ -231,6 +238,7 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
+	data.ID = types.StringValue(user.Email)
 	data.Email = types.StringValue(user.Email)
 	data.Name = types.StringValue(user.Name)
 

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -19,6 +19,7 @@ import (
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &UserResource{}
 var _ resource.ResourceWithValidateConfig = &UserResource{}
+var _ resource.ResourceWithImportState = &UserResource{}
 
 func NewUserResource() resource.Resource {
 	return &UserResource{}
@@ -111,6 +112,11 @@ func (r *UserResource) ValidateConfig(ctx context.Context, req resource.Validate
 			"global_permissions must contain at least one permission.",
 		)
 	}
+}
+
+func (r *UserResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Retrieve import ID and save to email attribute
+	resource.ImportStatePassthroughID(ctx, path.Root("email"), req, resp)
 }
 
 func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -53,6 +53,15 @@ func TestAccUserResource(t *testing.T) {
 					),
 				},
 			},
+			// ImportState testing
+			{
+				ResourceName:      "googleplay_user.oliver",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"global_permissions",
+				},
+			},
 			// Test update global permissions
 			{
 				Config: testAccUserResourceConfig(


### PR DESCRIPTION
Enable existing Google Play Console users to be imported into Terraform so that organisations can migrate their resources into Terraform management.